### PR TITLE
JOSS: Code Review @craddm & @anibalsolon

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@
 ^\.dir-locals\.el$
 ^\.vscode$
 ^\.travis\.yml$
+^ CONTRIBUTING\.md$
+^\.github$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^paper$
 ^\.dir-locals\.el$
 ^\.vscode$
+^\.travis\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+cache: packages
+warnings_are_errors: false
+r: release
+
+r_packages: 
+  - dplyr
+  - tidyr
+  - ggplot2
+  - lubridate
+  - checkmate
+  - rlang
+  - magrittr
+  - tibble
+  - testthat
+  - roxygen2
+
+# environment variables set for all builds
+env:
+  global:
+    - R_BUILD_ARGS="--no-build-vignettes --no-manual"
+    - R_CHECK_ARGS="--no-build-vignettes --no-manual"  ## do not build vignettes or manual
+
+r_build_args: --no-build-vignettes --no-manual
+r_check_args: --no-build-vignettes --no-manual

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ r_packages:
   - tibble
   - testthat
   - roxygen2
+  - covr
 
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: packages
 warnings_are_errors: false
 r: release
 
-r_packages: 
+r_packages:
   - dplyr
   - tidyr
   - ggplot2
@@ -16,6 +16,9 @@ r_packages:
   - tibble
   - testthat
   - roxygen2
+
+after_success:
+  - Rscript -e 'covr::codecov()'
 
 # environment variables set for all builds
 env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,6 @@ A brief list of coding conventions, which are somewhat atypical:
 - When naming objects, abbreviations and parameter names should use capitals as a first priority (e.g., `TPM_make_pvec` not `tpm_make_pvec`; but `unified_make_pvec` is fine).
 
 Development should be conducted on a separate branch. Tests are run using the `testthat` package automatically with Rstudio default.
-This can be envoked by pressing `ctrl + shift + T` in Windows or Linux. `Roxygen2` is used for all documentation.
+This can be invoked by pressing `ctrl + shift + T` in Windows or Linux. `roxygen2` is used for all documentation.
 
 Thankyou!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contribution Guidelines
+
+Thank you for showing interest in FIPS! We are excited to know you are interested in being apart of this community.
+
+We welcome contributions great or small from the community. Please do note that given the project is still in infancy,
+we would appreciate if you could contact us prior to submitting a large pull request. This is to ensure that we aren't
+doubling up on development efforts, and also we would love to hear from you!
+
+Currently we are a young project, maintained by a small team (_n_ = 3). Our primary focus over 2020 is expanding the
+FIPS user base. It would _incredibly_ useful to receive feedback via Github Issues for anything regarding the package,
+including: installation issues, bugs or unexpected behaviour, usability, feature requests or inquiries, or even
+something you don't understand in the tutorials about this class of models more generally. See specific details for each
+of these requests below:
+
+**Reporting a Bug:** If something has gone wrong with FIPS, would are grateful for your time to report the issue. Please
+use the provided "bug report template" when filing an issue. Please try to provide a minimal reproducible example (e.g.,
+via the suggested `reprex` package) where possible.
+
+**General BMM Questions:** If you have any general questions about the biomathematical models implemented in this
+package feel free to open a issue. We understand BMMs are a relatively novel class of models, and real research and
+practice circumstances often demand solutions beyond existing papers. Please do read the package documentation first,
+but it is useful for us to know if more information is required.
+
+**Data Importing:** A particular area where contributions would be appreciated is sleep data formats. If you have a
+relatively standard sleep data in a format that you are unable to import into FIPS, please do file an issue. While we
+cannot promise the resources to ensure your exact format is supported in FIPS, we will endeavor to do so, and warmly
+welcome collaborations aimed at expanding the supported data types.
+
+**Feature Requests:** We also welcome feature requests, but would kindly ask for citations/references to any requests
+for technical implementations.
+
+## Pull Requests & Code Conventions
+
+As mentioned, we would appreciate if you could contact us prior to submitting a large pull request. In particular, if
+you are interested in adding support for another form of BMM, please do reach out as this would prompt us to develop
+guidelines for adding models.
+
+A brief list of coding conventions, which are somewhat atypical:
+
+- Hard wrap source files to a 120 line margin (excluding comments or strings senstive to newlines)
+- Markdown files should be either unwrapped or 'filled' to 100 or 120 line margin in Emacs.
+- We use `<-` for function assignment, and `=` for variable assignment.
+- Underscores (i.e., snake-case) should separate words in object names. Period separation is currently used for legacy supported functions.
+- When naming objects, abbreviations and parameter names should use capitals as a first priority (e.g., `TPM_make_pvec` not `tpm_make_pvec`; but `unified_make_pvec` is fine).
+
+Thankyou!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,4 +43,7 @@ A brief list of coding conventions, which are somewhat atypical:
 - Underscores (i.e., snake-case) should separate words in object names. Period separation is currently used for legacy supported functions.
 - When naming objects, abbreviations and parameter names should use capitals as a first priority (e.g., `TPM_make_pvec` not `tpm_make_pvec`; but `unified_make_pvec` is fine).
 
+Development should be conducted on a separate branch. Tests are run using the `testthat` package automatically with Rstudio default.
+This can be envoked by pressing `ctrl + shift + T` in Windows or Linux. `Roxygen2` is used for all documentation.
+
 Thankyou!

--- a/R/FIPS-package.R
+++ b/R/FIPS-package.R
@@ -1,10 +1,18 @@
 #' FIPS: The Fatigue Impairment Prediction Suite
 #'
-#' The "Fatigue Impairment Prediction Suite" (FIPS) is currently under development and implemented in the R programming language. FIPS aims to provide practitioners a comprehensive set of functions for estimating and applying bio-mathematical models (BMMs).
+#' The "Fatigue Impairment Prediction Suite" (FIPS) is currently under development and implemented in the R programming language.
+#' FIPS provides researchers and practitioners comprehensive set of functions for applying bio-mathematical models (BMMs) of fatigue.
+#' FIPS is under active development and implemented in the R programming language.
+#' FIPS provides a set of well-documented functions for transforming sleep and actigraphy data to formats required for applying BMMs,
+#' as well as a set of functions for simulating and interpreting BMMs with several kinds of models and customisable parameter settings.
 #'
-#' FIPS provides researchers and practitioners comprehensive set of functions for applying bio-mathematical models (BMMs) of fatigue. FIPS is under active development and implemented in the R programming language. FIPS provides a set of well-documented functions for transforming sleep and actigraphy data to formats required for applying BMMs, as well as a set of functions for simulating and interpreting BMMs with several kinds of models and customisable parameter settings.
-#'
-#' BMMs are a class of biological phenomenological models which are used to predict the neuro-behavioural outcomes of fatigue (e.g., alertness, performance) using sleep-wake history. These models are frequently applied by defence and industrial sectors to support system safety as part of broader fatigue management strategies. FIPS is the first open-source BMM framework enabling practitioners to inspect, validate, and ideally extend BMMs. Although there are several different implementations of BMMs, most have their roots in Borbély's (1982) two process model which models sleepiness/performance impairment as the sum of two processes: a circadian process and a homeostatic process.
+#' BMMs are a class of biological phenomenological models which are used to predict the neuro-behavioural
+#' outcomes of fatigue (e.g., alertness, performance) using sleep-wake history.
+#' These models are frequently applied by defence and industrial sectors to support system
+#' safety as part of broader fatigue management strategies.
+#' FIPS is the first open-source BMM framework enabling practitioners to inspect, validate, and ideally extend BMMs.
+#' Although there are several different implementations of BMMs, most have their roots in Borbély's (1982)
+#'  two process model which models sleepiness/performance impairment as the sum of two processes: a circadian process and a homeostatic process.
 #'
 #' @import ggplot2
 #' @importFrom tibble tibble as_tibble

--- a/R/FIPS_plot.R
+++ b/R/FIPS_plot.R
@@ -72,7 +72,8 @@ FIPS_plot <- function(dats,
   sim_results$eod[sim_results$eod > max(sim_results$sim_hours)] <- NA
 
   plot_out <- ggplot2::ggplot(sim_results, aes(x = sim_hours)) +
-    geom_rect(aes(xmin = sleepstart, xmax = sleepend, ymin = -Inf, ymax = Inf, fill = 'Sleep'), alpha = 0.1, na.rm = T) +
+    geom_rect(aes(xmin = sleepstart, xmax = sleepend,
+                  ymin = -Inf, ymax = Inf, fill = 'Sleep'), alpha = 0.1, na.rm = T) +
     scale_fill_manual('Sleep', name = "", values = 'grey80', guide = guide_legend(override.aes = list(alpha = 1))) +
     geom_vline(aes(xintercept = eod), linetype = 2, na.rm = T) +
     theme_classic() +

--- a/R/data_singlevectorformat.R
+++ b/R/data_singlevectorformat.R
@@ -31,11 +31,18 @@ validate_epoch <- function(e) {
 #' @param seq A sequence of `0` (sleep) and `1` (wake) integers indicating sleep/wake status at that moment.
 #' @param epoch Integer expressing length of each observations in the series (minutes).
 #' @param series.start A POSIXct object indicating the start datetime of the simulation (i.e., pre-first sleep waking duration)
-#'
 #' @md
 #' @return `FIPS_df` formatted dataframe
 #' @export
-#'
+#' 
+#' @examples  
+#' start_date = as.POSIXct("2018-05-01 10:00:00")
+#' bitvector_sequence = rep(rep(c(1,0), 6), sample(20:40, 12))
+#' FIPSdf_from_bitvec = parse_sleepwake_sequence(
+#'  seq = bitvector_sequence,
+#'  series.start = start_date,
+#'  epoch = 15)
+#' 
 parse_sleepwake_sequence <- function(seq, epoch, series.start) {
 
     # Argument validation

--- a/R/data_sleeptimesformat.R
+++ b/R/data_sleeptimesformat.R
@@ -43,9 +43,9 @@
 #'    sleep.id.col = "sleep.id",
 #'    roundvalue = 5)
 #'
-#' @seealso 
+#' @seealso
 #' For binary input parsing see: [parse_sleepwake_sequence]
-#' 
+#'
 #' @return FIPS_df
 #'
 #' @export
@@ -56,9 +56,11 @@ parse_sleeptimes <- function(sleeptimes, series.start, series.end,
                              roundvalue = 5, sleep.start.col, sleep.end.col, sleep.id.col) {
 
   # Assert that series.start <= min(sleep.start.col) & length 1 & is a datetime & same timezones
-  checkmate::assert_posixct(series.start, upper = min(sleeptimes[[sleep.start.col]]), len = 1, .var.name = "series start datetime")
+  checkmate::assert_posixct(series.start, upper = min(sleeptimes[[sleep.start.col]]),
+                            len = 1, .var.name = "series start datetime")
   # Assert that simulation end time >= max(sleep.end.col) & length 1 & is a datetime & same timezones
-  checkmate::assert_posixct(series.end, lower = max(sleeptimes[[sleep.end.col]]), len = 1, .var.name = "series end datetime")
+  checkmate::assert_posixct(series.end, lower = max(sleeptimes[[sleep.end.col]]),
+                            len = 1, .var.name = "series end datetime")
   # Assert all sleep ends are less than simulation end times
   checkmate::assert_posixct(sleeptimes[[sleep.end.col]], upper = series.end, .var.name = "sleep.end datetimes")
   # Assert all sleep start times are less than sleep end times

--- a/R/data_sleeptimesformat.R
+++ b/R/data_sleeptimesformat.R
@@ -126,6 +126,7 @@ sleeptimes_to_FIPSdf = parse_sleeptimes
 #' @param firstsleep first sleep in the sleep dataframe
 #' @param expand_by expand
 #' @return returns expanded tibble containing sleep.id = NA (due to waking) and wake_status = T
+#' @keywords internal
 generate_presleep_times <- function(simulationstart, firstsleep, expand_by = 5) {
     if (simulationstart >= firstsleep)
       stop("[Developer] Simulation Start must before first sleep if using this function")
@@ -148,7 +149,7 @@ generate_presleep_times <- function(simulationstart, firstsleep, expand_by = 5) 
 #' @param expand_by expand value
 #'
 #' @return returns expanded tibble containing sleep.id = NA (due to waking) and wake_status = T
-#'
+#' @keywords internal
 #' @importFrom tibble tibble
 generate_postwake_times <- function(simulationend, lastwake, expand_by = 5) {
   if (simulationend <= lastwake)
@@ -187,6 +188,7 @@ round_times <- function(.data, colname, round_by = 5) {
 #' @param expand_by Amount (in minutes) to expand sleep times by
 #'
 #' @return Sleeptimedataframe with single columns vector for datetime and wake status
+#' @keywords internal
 expand_sleep_series <- function(.data, expand_by = 5) {
 
   emins = paste(expand_by, "mins")

--- a/R/simulation_threeprocessmodel.R
+++ b/R/simulation_threeprocessmodel.R
@@ -8,11 +8,11 @@
 TPM_check_pvec <- function(pvec) {
   accepted_names = c("la", "ha", "d", "g", "bl", "Cm", "Ca", "p", "Um", "Ua", "Wc", "Wd", "S0", "KSS_intercept", "KSS_beta")
   diffvals = setdiff(names(pvec), accepted_names)
-  if(length(diffvals) > 0) {
+  if (length(diffvals) > 0) {
     error_msg = sprintf("Three Process Model fit halted!:\n [%s] \n is/are unsupported parameters\n Please remove these parameters before continuing.", diffvals)
     stop(call. = F, error_msg)
   }
-  if(!all(accepted_names %in% names(pvec))) {
+  if (!all(accepted_names %in% names(pvec))) {
     stop(call. = F, "Three Process Model fit halted!:
          You have parameters missing (or renamed) in the supplied pvec.
          Please see help(TPM_make_pvec) for information about the required parameters.")

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Travis build status](https://travis-ci.com/humanfactors/FIPS.svg?branch=master)](https://travis-ci.com/humanfactors/FIPS)
+
 # Fatigue Impairment Prediction Suite (FIPS)
 
 <img align="right" src="inst/logo/FIPS_logo.png?raw=true" alt="FIPSLOGO" width="200"/> 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ simulated.dataframe = parse_sleeptimes(
   sleep.start.col = "sleep.start",
   sleep.end.col = "sleep.end",
   sleep.id.col = "sleep.id",
-  roundvalue = 5
-  )
+  roundvalue = 5)
 ```
 The resulting dataframe output (of class `FIPS_df`) can then be sent the simulation dispatch function `FIPS_simulate()`. The simulation functions require a parameter vector/list (pvec). Please see help for `TPM_make_pvec()` or `unified_make_pvec()` for more information on generating these vectors.
 
@@ -90,8 +89,7 @@ Calling `FIPS_simulate()` will produce a `FIPS_df` with model predictions and pr
 TPM.simulation.results = FIPS_simulate(
   FIPS_df = simulated.dataframe, # The FIPS_df
   modeltype = "TPM",             # three process model
-  pvec = TPM_make_pvec()       # parameter vector with defaults
-  )
+  pvec = TPM_make_pvec())       # parameter vector with defaults
 ```
 
 You now can access printing, summary and plot methods for the FIPS_simulation object. Note that further transformations to the object in dplyr and similar Tidyverse packages will remove attributes.
@@ -119,8 +117,7 @@ Wilson, M. D., Strickland, L. J. G., & Ballard, T. (2020, May 7). FIPS: An R Pac
  publisher={PsyArXiv},
  author={Wilson, Michael David and Strickland, Luke J G and Ballard, Timothy},
  year={2020},
- month={May}
-}
+ month={May}}
 ```
 
 # Authors

--- a/man/expand_sleep_series.Rd
+++ b/man/expand_sleep_series.Rd
@@ -17,3 +17,4 @@ Sleeptimedataframe with single columns vector for datetime and wake status
 \description{
 Turns the paired sleeptimes into a long single vectored datetime sequence
 }
+\keyword{internal}

--- a/man/generate_postwake_times.Rd
+++ b/man/generate_postwake_times.Rd
@@ -21,3 +21,4 @@ The last wake moment is unlikely to also be the end of the series.
 This function fills constructs a tibble with the all times between
 the final wake episode and the end of the series, intervaled by `expand_by` minutes
 }
+\keyword{internal}

--- a/man/generate_presleep_times.Rd
+++ b/man/generate_presleep_times.Rd
@@ -21,3 +21,4 @@ The first sleep is unlikely to also be the start of the mission simulation
 Thus, this function fills the start of the tibble with the all times between
 The mission start time and the first instance of sleep, intervaled by X minutes
 }
+\keyword{internal}

--- a/man/parse_sleepwake_sequence.Rd
+++ b/man/parse_sleepwake_sequence.Rd
@@ -21,3 +21,13 @@ It is common to have sleep wake history information in the form of a binary sequ
 This is the format used by SAFTE-FAST and other proprietary software.
 Further, this format is often easily exported by actigraphy measurement software.
 }
+\examples{
+ 
+start_date = as.POSIXct("2018-05-01 10:00:00")
+bitvector_sequence = rep(rep(c(1,0), 6), sample(20:40, 12))
+FIPSdf_from_bitvec = parse_sleepwake_sequence(
+ seq = bitvector_sequence,
+ series.start = start_date,
+ epoch = 15)
+
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -117,9 +117,9 @@ and a detailed tutorial in plotting model outputs.
 # FIPS Interface and Data Structures
 
 Conducting a BMM simulation in FIPS requires users to generate a `FIPS_df`, a
-tidy data frame containing a time series (based on sleep history) of all
+tidy data frame containing a time series (based on sleep history data) of all
 variables required to conduct BMM research. FIPS supports two sleep data
-formats, each format associated with a corresponding function that automatically
+formats, each format is associated with a corresponding function that automatically
 performs all required transformations to the `FIPS_df` format:
 
 -   The `parse_sleeptimes` function transforms a data frame containing three

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(FIPS)
+
+test_check("FIPS")

--- a/vignettes/FIPS-simulation-walkthrough.Rmd
+++ b/vignettes/FIPS-simulation-walkthrough.Rmd
@@ -31,10 +31,11 @@ library(colorspace)
 library(tidyr)
 ```
 
-## Data Generation
+## Data Preparation
 
-The dataframe below shows a prototypical FIPS 'sleep' dataframe. In the example, we want to simulate a scenario where an individual obtains exactly 7.5 hours of sleep per night for 6 nights. There are likely multiple ways to achieve this, but the generation function below allows 
-sufficient flexibility to have continuously offset sleeptimes (e.g., by changing `by != 24`).
+### Sleep Times Format
+
+The dataframe below shows a prototypical FIPS 'sleep times' dataframe. This form of dataframe is intended for individuals who are manually inputting sleep history (e.g., from pencil forms to a spreadsheet). Below, we generate this data structure ourselves for convenience. Specifically, we want to simulate a scenario where an individual obtains exactly 7.5 hours of sleep per night for 6 nights. There are likely multiple ways to achieve this, but the generation function below allows sufficient flexibility to have continuously offset sleeptimes (e.g., by changing `by = '24 hours'` to another value).
 
 The sleeptimes should correspond to only one participant (multiple people are not currently supported in FIPS without map functions). The default column names for this dataframe are `sleep.id`, `sleep.start`, and `sleep.end`. It is recommended that you explicitly specify timezones in all functions to avoid any silent errors relating to time zone specifications.
 
@@ -48,10 +49,9 @@ example.sleeptimes <- tibble::tibble(
   sleep.id = rank(sleep.start))
 
 print(example.sleeptimes)
-
 ```
 
-Prior to actually conducting the simulation, you _must_ convert the sleep times to the "Continuous FIPS Format". This format is a continuous time series style dataframe that contains calculated variables to be interpreted by the FIPS model functions. This dataframe contains the following headings: `datetime, sleep.id, wake_status, wake_status_int, change_point, switch_direction, status_duration, total_prev, time, day, sim_hours`. Information regarding these will be presented in the section below, but first let's quickly run through how to generate the FIPS dataframe from sleep times.
+Prior to actually conducting the simulation, you _must_ convert the sleep times to the continuous "FIPS_df" format. This format is a continuous time series style dataframe that contains calculated variables to be interpreted by the FIPS model functions. This dataframe contains the following headings: `datetime, sleep.id, wake_status, wake_status_int, change_point, switch_direction, status_duration, total_prev, time, day, sim_hours`. Information regarding these will be presented in the section below, but first let's quickly run through how to generate the FIPS dataframe from sleep times.
 
 The `parse_sleeptimes` function from FIPS will takes in 'sleep times' generated previously, and note the arguments below.
 
@@ -66,8 +66,6 @@ The `parse_sleeptimes` function from FIPS will takes in 'sleep times' generated 
 *The setting of `roundvalue` is critically important.* It determines the epoch or spacing between observations in your dataset (in minutes). At a value of `1`, the simulation is updated every 1 minute. Consequently, this will increase the size (in rows) of your dataset by a factor of 5 (relative to `5` minutes). In most cases, 5, 10 or even 15 minutes should be sufficient.
 
 Moreover, note that all sleep observations will have their datetime rounded to this value. For example, with a `roundvalue = 5` the datetime `2018-05-07 21:02:02` would be rounded to `2018-05-07 21:00:00`. For this reason, it is ideal if your `series.start` and `series.end` are rounded to the same epoch value as you request. Seconds should never be included in your datetime (biomathematical models are not sensitive to this time resolution anyway).
-
-
 
 ```{r}
 # Simulation start date time (i.e., when you want first predictions to begin)
@@ -89,6 +87,27 @@ simulated.dataframe = parse_sleeptimes(
   roundvalue = 5)
 
 print(simulated.dataframe)
+```
+### Bitvector Sequence Format
+
+It is common to represent sleep history information as a bitvector (i.e., a sequence of 1's and 0's). In bitvectors, sleep and wake times are represented by 1's or 0's, with each bit representing an equal time duration (e.g., 1 minute in that status). The bitvector sequence also must be relative to a *start datetime*. This format is commonly outputted from actigraphy devices (a form of wearable sleep tracker) and corresponding sleep detection algorithms (e.g., Cole-Kripke). Other proprietary software packages (e.g., SAFTE-FAST) require imported data to be in bit vector form (though the exact required formats do vary).
+
+`FIPS` expects bitvectors to repesent **sleep as 0** and **wake as 1**. The `parse_sleepwake_sequence` function can transform a bit vector sequence to a compliant `FIPS_df`. Below, an example of this data and steps to transform are provided, however, note that we do not use this dataframe again within this vignette.
+
+```{r}
+# Simulation start date time (i.e., when you want first predictions to begin)
+simulation.start = lubridate::ymd_hms('2018-05-01 10:00:00', tz = "Australia/Perth")
+
+# Example bitvector sequence. This typically would be imported directly via a textfile.
+# Here we generate, though typically this would be returned by a ReadLines/read.delim/read.table
+bv.sleep.sequence = rep(rep(c(1,0), 6), sample(20:40, 12))
+
+bv.sim.dataframe = parse_sleepwake_sequence(
+  seq = bv.sleep.sequence,
+  series.start = simulation.start,
+  epoch = 15)
+
+print(bv.sim.dataframe)
 ```
 
 ## Modelling and the Simulation Dataframe


### PR DESCRIPTION
This pull request addresses reviewer comments from @craddm on https://github.com/openjournals/joss-reviews/issues/2340
------------------
> I initially thought there were a few functions that don't currently have examples (e.g. expand_sleep_series()) that would benefit from them. But then I realized that those functions aren't exported, user-facing functions. You might want to make them internal functions (e.g. using @keywords internal) so that they don't show up in the user-facing API docs

Thanks for noticing this. I've now gone through and added the `@keywords internal` flag to all functions that are intended purely for developers (and have no useful purpose being in front-facing documentation)

> I'm not generally familiar with the area so have no example data of my own to test the package out. The package has a great vignette that generates data of the appropriate type, but one thing I'm left a little curious about is how you normally get data of that type. Specifically, there's a function mentioned in the pdf, parse_sleepwake_sequence(), that's intended for dealing with a common format used by other software for sleep/wake sequences. Examples of this type of data and the use of the function would be appreciated.

This is a good point, so to firstly address question directly. The _"sleep times"_ format used by `parse_sleeptimes` is predominately custom. A variety of sleep tracking applications return data in formats similar to this (though usually dramatically more complex). We intended the use case for this to be individuals who are transcribing a pen and paper sleep diary to digital via a spreadsheet. It turned out to also be a nice human readable format for generating simulation scenarios.

To make this point clearer, we now mention this fact explicitly in the `vignettes/FIPS-simulation-walkthrough.Rmd` to match the manuscript.

Now, to focus on your question regarding `parse_sleepwake_sequence()`, this format typically is returned by actigraphy device algorithms (though sometimes labeled with `S` and `W` for sleep/wake). For instance, the [dipetkov/actigraph.sleepr](https://github.com/dipetkov/actigraph.sleepr) package will convert raw actigraphy data to a bitvector. There are many different ways of presenting this, but all our devices have returned it in a newline separated `.txt` file with a comment header line and then just a series of `S` and `W`.

We've made a number of changes to the repository to make clearer what FIPS expects the bitvector to look like, and how to handle such data. Specifically:

- We added an entire section to `vignettes/FIPS-simulation-walkthrough.Rmd` entitled _Bitvector Sequence Format_, which shows a full example of using the `parse_sleepwake_sequence` function.
- We have added an `@examples` section to the function documentation of `parse_sleepwake_sequence`

> I can see you have some tests set up using testthat, which is great. But I'd also suggest hooking them up to a continuous integration service such as Travis-CI.

Thank you for this encouragement. I had no prior experience with Travis CI, but am glad to now have a successful automated integration build. I believe I've configured this appropriately in `f450fad`. Screenshot of test passed below.

![image](https://user-images.githubusercontent.com/16096044/86889879-0c2b2800-c12f-11ea-8429-d5807f430953.png)

