### PR TITLE
Fixed bug not supporting the custom names + add test

### DIFF
--- a/R/data_sleeptimesformat.R
+++ b/R/data_sleeptimesformat.R
@@ -55,6 +55,15 @@
 parse_sleeptimes <- function(sleeptimes, series.start, series.end,
                              roundvalue = 5, sleep.start.col, sleep.end.col, sleep.id.col) {
 
+  # Assert all colnames specified are actually in sleeptimes
+  valid_names = checkmate::check_names(
+    names(sleeptimes), permutation.of = c(sleep.id.col, sleep.start.col, sleep.end.col), what = "colnames")
+
+  # Let's give a very useful message for this one.
+  if(valid_names != T) {
+    stop("At least one of the column strings you have specified does not exist in the sleeptimes dataframe. ",
+         valid_names)}
+
   # Assert that series.start <= min(sleep.start.col) & length 1 & is a datetime & same timezones
   checkmate::assert_posixct(series.start, upper = min(sleeptimes[[sleep.start.col]]),
                             len = 1, .var.name = "series start datetime")
@@ -85,8 +94,8 @@ parse_sleeptimes <- function(sleeptimes, series.start, series.end,
     dplyr::mutate(sleep.end = sleep.end - lubridate::minutes(roundvalue))
 
   # Assign minimum sleep start
-  minimum.sleepstart = min(rounded.sleeptimes[[sleep.start.col]])
-  maximum.sleepend = max(rounded.sleeptimes[[sleep.end.col]])
+  minimum.sleepstart = min(rounded.sleeptimes[["sleep.start"]])
+  maximum.sleepend = max(rounded.sleeptimes[["sleep.end"]])
 
   # Now expand out the series of sleep wake times
   processed.sleeptimes <- expand_sleep_series(rounded.sleeptimes, expand_by = roundvalue)
@@ -202,3 +211,4 @@ expand_sleep_series <- function(.data, expand_by = 5) {
     dplyr::ungroup() %>%
     tidyr::complete(datetime = seq(min(datetime), max(datetime), by = emins), fill = list(wake_status = T))
 }
+

--- a/tests/testthat/test-data_sleeptimesformat.R
+++ b/tests/testthat/test-data_sleeptimesformat.R
@@ -16,6 +16,9 @@ unit_sleeptimes = tibble::tribble(
 unit_simstart = ymd_hms('2018-05-20 22:00:00', tz = perth)
 unit_simend   = ymd_hms('2018-05-23 10:00:00', tz = perth)
 
+unit_sleeptimes_renamed = unit_sleeptimes %>%
+  dplyr::rename(sleep_id = sleep.id, sleep_start = sleep.start, sleep_end = sleep.end)
+
 test_that(
   "parse_sleeptimes executes and expands out correctly.", {
     unit_parsedtimes = parse_sleeptimes(
@@ -44,6 +47,37 @@ test_that(
     # all switch directions to sleep should be associated with a wake_status of F
     expect_true(all(dplyr::filter(unitpar_switches, wake_status == F)[["switch_direction"]] == "Sleep"))
   })
+
+
+test_that("parse_sleeptimes handles series.start and ends named differently from default", {
+
+  unit_parsedtimes = parse_sleeptimes(
+    sleeptimes = unit_sleeptimes_renamed,
+    series.start = unit_simstart,
+    series.end = unit_simend,
+    sleep.start.col = "sleep_start",
+    sleep.end.col = "sleep_end",
+    sleep.id.col = "sleep_id",
+    roundvalue = 5)
+
+  expect_s3_class(unit_parsedtimes, "FIPS_df")
+
+})
+
+test_that("If column name not found, a useful error message is provided", {
+  expect_error(
+    parse_sleeptimes(
+    sleeptimes = unit_sleeptimes_renamed,
+    series.start = unit_simstart,
+    series.end = unit_simend,
+    sleep.start.col = "sleep_start",
+    sleep.end.col = "sleep_end",
+    sleep.id.col = "sleep_x_id",
+    roundvalue = 5), regexp = "At least one of the column")
+
+})
+
+
 
 
 test_that("parse_sleeptimes handles series.start and ends that are identical to max/min sleeps", {


### PR DESCRIPTION
Basically was becuase a function was still referencing old string names later on. Now have a test to make sure names exist also. Added unit tests to ensure this example covered.

Resolves #7 