### PR TITLE
roundvalue decimal (second level) precision warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,5 +28,5 @@ Suggests:
     testthat (>= 2.1.0),
     rmarkdown (>= 2.0),
     knitr
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr

--- a/R/data_sleeptimesformat.R
+++ b/R/data_sleeptimesformat.R
@@ -15,10 +15,10 @@
 #' @param sleeptimes A dataframe in the sleep time format (see help for more info)
 #' @param series.start A POSIXct object indicating the start datetime of the simulation (i.e., pre-first sleep waking duration)
 #' @param series.end  A POSIXct object indicating the end datetime of the simulation
-#' @param roundvalue A value to round the sleep times to in minutes (`default = 5 minutes`)
-#' @param sleep.start.col The column in the dataframe containing the sleep start times
-#' @param sleep.end.col The column name in the dataframe containing the sleep end times
-#' @param sleep.id.col A column name specifying the sleep id sequence (i.e., `1:n()`)
+#' @param roundvalue An whole numeric (integer) value to round the sleep times to in minutes (`default = 5 minutes`). Second precision not supported.
+#' @param sleep.start.col [string] The column in the dataframe containing the sleep start times
+#' @param sleep.end.col [string] The column name in the dataframe containing the sleep end times
+#' @param sleep.id.col [string] A column name specifying the sleep id sequence (i.e., `1:n()`)
 #'
 #' @examples
 #'
@@ -76,6 +76,16 @@ parse_sleeptimes <- function(sleeptimes, series.start, series.end,
   checkmate::assert_true(all(sleeptimes[[sleep.start.col]] < sleeptimes[[sleep.end.col]]))
   # Assert that ALL sleep end times <= series.end & all are a datetime & same timezone
   checkmate::assert_posixct(sleeptimes[[sleep.start.col]], lower = series.start, .var.name = "sleep.start datetimes")
+
+  # roundvalue checks for whole number, as second precision not supported
+  if(roundvalue < 1) stop("roundvalue must be a whole number > 1. FIPS does not support second-level precision")
+  if(!(roundvalue%%1==0)) {
+    # Print warning
+    warning(paste("roundvalue must be a whole number > 1. FIPS does not support second-level precision.",
+                  "User set round value of", roundvalue, "now set to", round(roundvalue)))
+    # round userinput
+    roundvalue = round(roundvalue)}
+
 
 
   # Now rename the user supplied sleeptime columns to "sleep.id", "sleep.start", and "sleep.end".

--- a/man/parse_sleeptimes.Rd
+++ b/man/parse_sleeptimes.Rd
@@ -32,13 +32,13 @@ sleeptimes_to_FIPSdf(
 
 \item{series.end}{A POSIXct object indicating the end datetime of the simulation}
 
-\item{roundvalue}{A value to round the sleep times to in minutes (\verb{default = 5 minutes})}
+\item{roundvalue}{An whole numeric (integer) value to round the sleep times to in minutes (\verb{default = 5 minutes}). Second precision not supported.}
 
-\item{sleep.start.col}{The column in the dataframe containing the sleep start times}
+\item{sleep.start.col}{\link{string} The column in the dataframe containing the sleep start times}
 
-\item{sleep.end.col}{The column name in the dataframe containing the sleep end times}
+\item{sleep.end.col}{\link{string} The column name in the dataframe containing the sleep end times}
 
-\item{sleep.id.col}{A column name specifying the sleep id sequence (i.e., \code{1:n()})}
+\item{sleep.id.col}{\link{string} A column name specifying the sleep id sequence (i.e., \code{1:n()})}
 }
 \value{
 FIPS_df

--- a/tests/testthat/test-data_sleeptimesformat.R
+++ b/tests/testthat/test-data_sleeptimesformat.R
@@ -79,6 +79,34 @@ test_that("If column name not found, a useful error message is provided", {
 
 
 
+test_that("If user supplies roundvalue > 1 and not whole number, it is handled.", {
+
+  expect_warning(
+    parse_sleeptimes(
+      sleeptimes = unit_sleeptimes,
+      series.start = unit_simstart,
+      series.end = unit_simend,
+      sleep.start.col = "sleep.start",
+      sleep.end.col = "sleep.end",
+      sleep.id.col = "sleep.id",
+      roundvalue = 6.3), regexp = "roundvalue must be a whole number")
+
+})
+
+
+test_that("If user supplies roundvalue < 1, error handled and thrown.", {
+  expect_error(
+    parse_sleeptimes(
+      sleeptimes = unit_sleeptimes,
+      series.start = unit_simstart,
+      series.end = unit_simend,
+      sleep.start.col = "sleep.start",
+      sleep.end.col = "sleep.end",
+      sleep.id.col = "sleep.id",
+      roundvalue = 0.5), regexp = "roundvalue must be a whole number")
+
+})
+
 
 test_that("parse_sleeptimes handles series.start and ends that are identical to max/min sleeps", {
 


### PR DESCRIPTION
- Added warnings/errors for users trying to set roundvalue to not whole number.
- Added unit tests supporting above
- Added docstrings help update to specify roundvalue changes

Addresses Issue #9 